### PR TITLE
Fixed ordering for diffing between parent and child

### DIFF
--- a/src/bggit_part_092_diff.md
+++ b/src/bggit_part_092_diff.md
@@ -215,10 +215,10 @@ $ git diff HEAD 27a3
 Or relative `HEAD`:
 
 ``` {.default}
-$ git diff HEAD~3 HEAD~4
+$ git diff HEAD~4 HEAD~3
 ```
 
-That last one diffs three commits before `HEAD` with four commits before
+That last one diffs four commits before `HEAD` with three commits before
 `HEAD`.
 
 ### Diffing with Parent Commit
@@ -227,14 +227,14 @@ That last one diffs three commits before `HEAD` with four commits before
 We just showed this example:
 
 ``` {.default}
-$ git diff HEAD~3 HEAD~4
+$ git diff HEAD~4 HEAD~3
 ```
 
 But since `HEAD~4` is the parent of `HEAD~3`, is there some shorthand we
 can use here? Yes!
 
 ``` {.default}
-$ git diff HEAD~3 HEAD~4
+$ git diff HEAD~4 HEAD~3
 $ git diff HEAD~3^!          # Same thing!
 ```
 


### PR DESCRIPTION
It was incorrectly written that `git diff HEAD~3 HEAD~4` is the same as `git diff HEAD~3^!`.

It is actually the case that `git diff HEAD~3^!` is the same as `git diff HEAD~4 HEAD~3`

When you want to diff a commit with its parent, you usually mean you want to know what changes you need to get to get from the parent to the child commit.

Some more explanation regarding this and the order you specify the commits to diff would also be great.

---

Great book btw. 